### PR TITLE
OAuth2 Support

### DIFF
--- a/dropbox-api.gemspec
+++ b/dropbox-api.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'multi_json'
   s.add_dependency 'oauth'
+  s.add_dependency 'oauth2'
   s.add_dependency 'hashie'
 
   s.files         = `git ls-files`.split("\n")

--- a/lib/dropbox-api.rb
+++ b/lib/dropbox-api.rb
@@ -11,6 +11,7 @@ end
 require "dropbox-api/version"
 require "dropbox-api/util/config"
 require "dropbox-api/util/oauth"
+require "dropbox-api/util/oauth2"
 require "dropbox-api/util/error"
 require "dropbox-api/util/util"
 require "dropbox-api/objects/object"

--- a/lib/dropbox-api/client/raw.rb
+++ b/lib/dropbox-api/client/raw.rb
@@ -31,6 +31,7 @@ module Dropbox
 
       add_method :get,  "/metadata/:root/:path",   :as => 'metadata'
       add_method :post, "/delta",                  :as => 'delta', :root => false
+      add_method :post, "/delta/latest_cursor",    :as => 'delta_cursor', :root => false
       add_method :get,  "/revisions/:root/:path",  :as => 'revisions'
       add_method :post, "/restore/:root/:path",    :as => 'restore'
       add_method :get,  "/search/:root/:path",     :as => 'search'

--- a/lib/dropbox-api/connection.rb
+++ b/lib/dropbox-api/connection.rb
@@ -15,8 +15,9 @@ module Dropbox
         @consumers = {}
         @tokens    = {}
         Dropbox::API::Config.endpoints.each do |endpoint, url|
-          @consumers[endpoint] = Dropbox::API::OAuth.consumer(endpoint)
-          @tokens[endpoint]    = Dropbox::API::OAuth.access_token(@consumers[endpoint], options)
+          auth_class = Dropbox::API::Config.auth_type == 'oauth2' ? Dropbox::API::OAuth2 : Dropbox::API::OAuth
+          @consumers[endpoint] = auth_class.consumer(endpoint)
+          @tokens[endpoint]    = auth_class.access_token(@consumers[endpoint], options)
         end
       end
 

--- a/lib/dropbox-api/connection/requests.rb
+++ b/lib/dropbox-api/connection/requests.rb
@@ -52,7 +52,7 @@ module Dropbox
           request_url = "#{Dropbox::API::Config.prefix}#{path}?#{URI.parse(URI.encode(query))}"
           request(:raw => true) do
             if token.is_a?(::OAuth2::AccessToken)
-              token(endpoint).get request_url, headers: headers
+              token(endpoint).get request_url, headers => headers
             else
               token(endpoint).get request_url, headers
             end
@@ -64,7 +64,7 @@ module Dropbox
           request_url = "#{Dropbox::API::Config.prefix}#{path}?#{URI.parse(URI.encode(query))}"
           request do
             if token.is_a?(::OAuth2::AccessToken)
-              token(endpoint).get request_url, headers: headers
+              token(endpoint).get request_url, headers => headers
             else
               token(endpoint).get request_url, headers
             end
@@ -75,7 +75,7 @@ module Dropbox
           request_url = "#{Dropbox::API::Config.prefix}#{path}"
           request do
             if token.is_a?(::OAuth2::AccessToken)
-              token(endpoint).post request_url, params: data, headers: headers
+              token(endpoint).post request_url, params => data, headers => headers
             else
               token(endpoint).post request_url, data, headers
             end
@@ -86,7 +86,7 @@ module Dropbox
           request_url = "#{Dropbox::API::Config.prefix}#{path}"
           request do
             if token.is_a?(::OAuth2::AccessToken)
-              token(endpoint).put request_url, params: data, headers: headers
+              token(endpoint).put request_url, params => data, headers => headers
             else
               token(endpoint).put request_url, data, headers
             end

--- a/lib/dropbox-api/connection/requests.rb
+++ b/lib/dropbox-api/connection/requests.rb
@@ -49,42 +49,46 @@ module Dropbox
 
         def get_raw(endpoint, path, data = {}, headers = {})
           query = Dropbox::API::Util.query(data)
+          request_url = "#{Dropbox::API::Config.prefix}#{path}?#{URI.parse(URI.encode(query))}"
           request(:raw => true) do
             if token.is_a?(::OAuth2::AccessToken)
-              token(endpoint).get "#{Dropbox::API::Config.prefix}#{path}?#{URI.parse(URI.encode(query))}", headers: headers
+              token(endpoint).get request_url, headers: headers
             else
-              token(endpoint).get "#{Dropbox::API::Config.prefix}#{path}?#{URI.parse(URI.encode(query))}", headers
+              token(endpoint).get request_url, headers
             end
           end
         end
 
         def get(endpoint, path, data = {}, headers = {})
           query = Dropbox::API::Util.query(data)
+          request_url = "#{Dropbox::API::Config.prefix}#{path}?#{URI.parse(URI.encode(query))}"
           request do
             if token.is_a?(::OAuth2::AccessToken)
-              token(endpoint).get "#{Dropbox::API::Config.prefix}#{path}?#{URI.parse(URI.encode(query))}", headers: headers
+              token(endpoint).get request_url, headers: headers
             else
-              token(endpoint).get "#{Dropbox::API::Config.prefix}#{path}?#{URI.parse(URI.encode(query))}", headers
+              token(endpoint).get request_url, headers
             end
           end
         end
 
         def post(endpoint, path, data = {}, headers = {})
+          request_url = "#{Dropbox::API::Config.prefix}#{path}"
           request do
             if token.is_a?(::OAuth2::AccessToken)
-              token(endpoint).post "#{Dropbox::API::Config.prefix}#{path}", params: data, headers: headers
+              token(endpoint).post request_url, params: data, headers: headers
             else
-              token(endpoint).post "#{Dropbox::API::Config.prefix}#{path}", data, headers
+              token(endpoint).post request_url, data, headers
             end
           end
         end
 
         def put(endpoint, path, data = {}, headers = {})
+          request_url = "#{Dropbox::API::Config.prefix}#{path}"
           request do
             if token.is_a?(::OAuth2::AccessToken)
-              token(endpoint).put "#{Dropbox::API::Config.prefix}#{path}", params: data, headers: headers
+              token(endpoint).put request_url, params: data, headers: headers
             else
-              token(endpoint).put "#{Dropbox::API::Config.prefix}#{path}", data, headers
+              token(endpoint).put request_url, data, headers
             end
           end
         end

--- a/lib/dropbox-api/connection/requests.rb
+++ b/lib/dropbox-api/connection/requests.rb
@@ -52,7 +52,7 @@ module Dropbox
           request_url = "#{Dropbox::API::Config.prefix}#{path}?#{URI.parse(URI.encode(query))}"
           request(:raw => true) do
             if token.is_a?(::OAuth2::AccessToken)
-              token(endpoint).get request_url, headers => headers
+              token(endpoint).get request_url, :headers => headers
             else
               token(endpoint).get request_url, headers
             end
@@ -64,7 +64,7 @@ module Dropbox
           request_url = "#{Dropbox::API::Config.prefix}#{path}?#{URI.parse(URI.encode(query))}"
           request do
             if token.is_a?(::OAuth2::AccessToken)
-              token(endpoint).get request_url, headers => headers
+              token(endpoint).get request_url, :headers => headers
             else
               token(endpoint).get request_url, headers
             end
@@ -75,7 +75,7 @@ module Dropbox
           request_url = "#{Dropbox::API::Config.prefix}#{path}"
           request do
             if token.is_a?(::OAuth2::AccessToken)
-              token(endpoint).post request_url, params => data, headers => headers
+              token(endpoint).post request_url, :params => data, :headers => headers
             else
               token(endpoint).post request_url, data, headers
             end
@@ -86,7 +86,7 @@ module Dropbox
           request_url = "#{Dropbox::API::Config.prefix}#{path}"
           request do
             if token.is_a?(::OAuth2::AccessToken)
-              token(endpoint).put request_url, params => data, headers => headers
+              token(endpoint).put request_url, :params => data, :headers => headers
             else
               token(endpoint).put request_url, data, headers
             end

--- a/lib/dropbox-api/connection/requests.rb
+++ b/lib/dropbox-api/connection/requests.rb
@@ -8,7 +8,7 @@ module Dropbox
         def request(options = {})
           response = yield
           raise Dropbox::API::Error::ConnectionFailed if !response
-          status = response.code.to_i
+          status = (response.respond_to?(:code) ? response.code : response.status).to_i
           case status
             when 400
               parsed = MultiJson.decode(response.body)

--- a/lib/dropbox-api/connection/requests.rb
+++ b/lib/dropbox-api/connection/requests.rb
@@ -50,26 +50,42 @@ module Dropbox
         def get_raw(endpoint, path, data = {}, headers = {})
           query = Dropbox::API::Util.query(data)
           request(:raw => true) do
-            token(endpoint).get "#{Dropbox::API::Config.prefix}#{path}?#{URI.parse(URI.encode(query))}", headers
+            if token.is_a?(::OAuth2::AccessToken)
+              token(endpoint).get "#{Dropbox::API::Config.prefix}#{path}?#{URI.parse(URI.encode(query))}", headers: headers
+            else
+              token(endpoint).get "#{Dropbox::API::Config.prefix}#{path}?#{URI.parse(URI.encode(query))}", headers
+            end
           end
         end
 
         def get(endpoint, path, data = {}, headers = {})
           query = Dropbox::API::Util.query(data)
           request do
-            token(endpoint).get "#{Dropbox::API::Config.prefix}#{path}?#{URI.parse(URI.encode(query))}", headers
+            if token.is_a?(::OAuth2::AccessToken)
+              token(endpoint).get "#{Dropbox::API::Config.prefix}#{path}?#{URI.parse(URI.encode(query))}", headers: headers
+            else
+              token(endpoint).get "#{Dropbox::API::Config.prefix}#{path}?#{URI.parse(URI.encode(query))}", headers
+            end
           end
         end
 
         def post(endpoint, path, data = {}, headers = {})
           request do
-            token(endpoint).post "#{Dropbox::API::Config.prefix}#{path}", data, headers
+            if token.is_a?(::OAuth2::AccessToken)
+              token(endpoint).post "#{Dropbox::API::Config.prefix}#{path}", params: data, headers: headers
+            else
+              token(endpoint).post "#{Dropbox::API::Config.prefix}#{path}", data, headers
+            end
           end
         end
 
         def put(endpoint, path, data = {}, headers = {})
           request do
-            token(endpoint).put "#{Dropbox::API::Config.prefix}#{path}", data, headers
+            if token.is_a?(::OAuth2::AccessToken)
+              token(endpoint).put "#{Dropbox::API::Config.prefix}#{path}", params: data, headers: headers
+            else
+              token(endpoint).put "#{Dropbox::API::Config.prefix}#{path}", data, headers
+            end
           end
         end
 

--- a/lib/dropbox-api/tasks.rb
+++ b/lib/dropbox-api/tasks.rb
@@ -38,6 +38,35 @@ module Dropbox
             puts "  client = Dropbox::API::Client.new(:token  => '#{access_token.token}', :secret => '#{access_token.secret}')"
             puts "\n"
           end
+
+          desc "Authorize wizard for Dropbox API OAuth2"
+          task :authorize_oauth2 do
+            require "oauth2"
+            require "dropbox-api"
+            require "cgi"
+            print "Enter dropbox app key: "
+            consumer_key = $stdin.gets.chomp
+            print "Enter dropbox app secret: "
+            consumer_secret = $stdin.gets.chomp
+
+            Dropbox::API::Config.app_key    = consumer_key
+            Dropbox::API::Config.app_secret = consumer_secret
+
+            consumer = ::Dropbox::API::OAuth2.consumer(:authorize)
+            authorize_uri = consumer.authorize_url(client_id: Dropbox::API::Config.app_key, response_type: 'code')
+            puts "\nGo to this url and click 'Authorize' to get the token:"
+            puts authorize_uri
+            print "\nOnce you authorize the app on Dropbox, paste the code here and press enter:"
+            code = $stdin.gets.chomp
+
+            access_token = consumer.auth_code.get_token(code)
+            puts "\nAuthorization complete!:\n\n"
+            puts "  Dropbox::API::Config.app_key    = '#{consumer_key}'"
+            puts "  Dropbox::API::Config.app_secret = '#{consumer_secret}'"
+            puts "  client = Dropbox::API::Client.new(:token  => '#{access_token.token}')"
+            puts "\n"
+          end
+
         end
 
       end

--- a/lib/dropbox-api/util/config.rb
+++ b/lib/dropbox-api/util/config.rb
@@ -9,6 +9,7 @@ module Dropbox
         attr_accessor :app_key
         attr_accessor :app_secret
         attr_accessor :mode
+        attr_accessor :auth_type
       end
 
       self.endpoints = {
@@ -20,6 +21,7 @@ module Dropbox
       self.app_key    = nil
       self.app_secret = nil
       self.mode       = 'sandbox'
+      self.auth_type  = 'oauth'
 
     end
 

--- a/lib/dropbox-api/util/oauth2.rb
+++ b/lib/dropbox-api/util/oauth2.rb
@@ -12,7 +12,7 @@ module Dropbox
           ::OAuth2::Client.new(Dropbox::API::Config.app_key, Dropbox::API::Config.app_secret,
             :site               => Dropbox::API::Config.endpoints[endpoint],
             :authorize_url      => "#{Dropbox::API::Config.prefix}/oauth2/authorize",
-            :token_url  => "#{Dropbox::API::Config.prefix}/oauth2/token")
+            :token_url          => "#{Dropbox::API::Config.prefix}/oauth2/token")
         end
 
         def access_token(konsumer, options = {})

--- a/lib/dropbox-api/util/oauth2.rb
+++ b/lib/dropbox-api/util/oauth2.rb
@@ -1,0 +1,28 @@
+module Dropbox
+  module API
+
+    module OAuth2
+
+      class << self
+
+        def consumer(endpoint)
+          if !Dropbox::API::Config.app_key or !Dropbox::API::Config.app_secret
+            raise Dropbox::API::Error::Config.new("app_key or app_secret not provided")
+          end
+          ::OAuth2::Client.new(Dropbox::API::Config.app_key, Dropbox::API::Config.app_secret,
+            :site               => Dropbox::API::Config.endpoints[endpoint],
+            :authorize_url      => "#{Dropbox::API::Config.prefix}/oauth2/authorize",
+            :token_url  => "#{Dropbox::API::Config.prefix}/oauth2/token")
+        end
+
+        def access_token(konsumer, options = {})
+          ::OAuth2::AccessToken.new(konsumer, options[:token], options)
+        end
+
+      end
+
+    end
+
+  end
+end
+


### PR DESCRIPTION
I needed to modify dropbox-api to support OAuth2 and figured I'd submit my changes as a PR. Dropbox mentions in their docs that:

> OAuth 1.0 continues to be supported for all API requests, but OAuth 2.0 is now preferred.

This change adds a new config setting `auth_type` which can be either `oauth` (default) or `oauth2`:

```ruby
Dropbox::API::Config.auth_type = "oauth2" # default is oauth
```
It also slightly changes the way that Access Tokens are requested when OAuth2 is used:

```ruby
## Manual Access Token retrieval:

consumer = ::Dropbox::API::OAuth2.consumer(:authorize)
authorize_uri = consumer.authorize_url(client_id: APP_KEY, response_type: 'code')
# open authorize_uri in browser, sign in, grant permission, copy code that is displayed
access_token = consumer.auth_code.get_token('code_from_dropbox')

# Browser-based Access Token retrieval:

consumer = ::Dropbox::API::OAuth2.consumer(:authorize)
authorize_uri = consumer.authorize_url(client_id: APP_KEY, response_type: 'code', redirect_uri: 'https://yoursite.com/dropbox_landing', state: 'optional string')
# redirect user to authorize_uri
# upon return to https://yoursite.com/dropbox_landing?code=SOME_CODE&uid=SOME_ID
access_token = consumer.auth_code.get_token('code_from_query_string')
```